### PR TITLE
fix: no poetry.lock in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /deps
 RUN pip --no-cache-dir install --progress-bar=off "poetry==1.8"
 
 COPY pyproject.toml .
-COPY poetry.lock .
 RUN poetry install -nvvv --only main --no-root; mv $(poetry env info --path) ./venv
 
 FROM runtime


### PR DESCRIPTION
it's not in the repo so won't be there during ci