### PR TITLE
2.22.6 - Fix for critical bug introduced in 2.22.5

### DIFF
--- a/fred/config.py
+++ b/fred/config.py
@@ -19,7 +19,7 @@ class PermissionRoles(SQLObject):
     role_name = StringCol()
 
     @staticmethod
-    def fetch_by_lvl(perm_lvl: int) -> list[PermissionRoles]:
+    def fetch_ge_lvl(perm_lvl: int) -> list[PermissionRoles]:
         query = PermissionRoles.select(PermissionRoles.q.perm_lvl >= perm_lvl).orderBy("-perm_lvl")
         return list(query)
 


### PR DESCRIPTION
When a user didn't meet a permission check the logging failed because role was a bool. I've rewritten how the check works so it's not duplicating effort and makes more sense.